### PR TITLE
Add run_fw.py creation to fuzz.py and the --project option to CreateBaseDir.py

### DIFF
--- a/DICE-Evaluation/ARM/Fuzzing/CreateBaseDir.py
+++ b/DICE-Evaluation/ARM/Fuzzing/CreateBaseDir.py
@@ -39,8 +39,13 @@ if __name__ == "__main__":
         help="fuzzing run number")
     parser.add_argument("-B", "--base", dest="base", default="FuzzDir",
         help="base dir for fuzzing ")
+    parser.add_argument("-P", "--project", dest="project", default="",
+        help="project name (if unspecified, generates for all built-in projects)")
 
     args = parser.parse_args()
+
+    if len(args.project) != 0:
+        dirs = [args.project]
 
     base = args.base
     run_num = args.run


### PR DESCRIPTION
This pull request adds back the `run_fw.py` script creation that p2im used to create, and adds `--project` flag to `CreateBaseDir.py` so it can create the directories for other project names (or just not all at once). Neither is a major issue, but more just a convenience for those using the tool. 